### PR TITLE
Adding iOS targets.

### DIFF
--- a/buildSrc/src/main/kotlin/kotlin-library-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-library-convention.gradle.kts
@@ -58,6 +58,15 @@ kotlin {
         else -> throw GradleException("Host OS is not supported in Kotlin/Native.")
     }
 
+    listOf(
+        iosX64(),
+        iosArm64(),
+    ).forEach {
+        it.binaries.framework {
+            baseName = "mutator"
+        }
+    }
+
     sourceSets {
         val commonMain by getting
         val commonTest by getting {
@@ -69,6 +78,12 @@ kotlin {
         val jvmTest by getting
         val nativeMain by getting
         val nativeTest by getting
+        val iosMain by creating {
+            dependsOn(commonMain)
+        }
+        val iosTest by creating {
+            dependsOn(commonTest)
+        }
     }
 }
 
@@ -86,7 +101,13 @@ allprojects {
     }
 }
 
-val dokkaHtml by tasks.getting(org.jetbrains.dokka.gradle.DokkaTask::class)
+val dokkaHtml by tasks.getting(org.jetbrains.dokka.gradle.DokkaTask::class) {
+    dokkaSourceSets {
+        named("iosTest") {
+            suppress.set(true)
+        }
+    }
+}
 
 val javadocJar: TaskProvider<Jar> by tasks.registering(Jar::class) {
     dependsOn(dokkaHtml)

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -16,4 +16,35 @@
 
 plugins {
     `kotlin-library-convention`
+    kotlin("multiplatform")
+}
+
+kotlin {
+    listOf(
+        iosX64(),
+        iosArm64(),
+    ).forEach {
+        it.binaries.framework {
+            baseName = "mutator-coroutines"
+        }
+    }
+
+    sourceSets {
+        val commonMain by getting
+        val commonTest by getting
+        val iosX64Main by getting
+        val iosArm64Main by getting
+        val iosMain by creating {
+            dependsOn(commonMain)
+            iosX64Main.dependsOn(this)
+            iosArm64Main.dependsOn(this)
+        }
+        val iosX64Test by getting
+        val iosArm64Test by getting
+        val iosTest by creating {
+            dependsOn(commonTest)
+            iosX64Test.dependsOn(this)
+            iosArm64Test.dependsOn(this)
+        }
+    }
 }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -16,35 +16,4 @@
 
 plugins {
     `kotlin-library-convention`
-    kotlin("multiplatform")
-}
-
-kotlin {
-    listOf(
-        iosX64(),
-        iosArm64(),
-    ).forEach {
-        it.binaries.framework {
-            baseName = "mutator-coroutines"
-        }
-    }
-
-    sourceSets {
-        val commonMain by getting
-        val commonTest by getting
-        val iosX64Main by getting
-        val iosArm64Main by getting
-        val iosMain by creating {
-            dependsOn(commonMain)
-            iosX64Main.dependsOn(this)
-            iosArm64Main.dependsOn(this)
-        }
-        val iosX64Test by getting
-        val iosArm64Test by getting
-        val iosTest by creating {
-            dependsOn(commonTest)
-            iosX64Test.dependsOn(this)
-            iosArm64Test.dependsOn(this)
-        }
-    }
 }

--- a/coroutines/build.gradle.kts
+++ b/coroutines/build.gradle.kts
@@ -16,19 +16,9 @@
 
 plugins {
     `kotlin-library-convention`
-    kotlin("multiplatform")
 }
 
 kotlin {
-    listOf(
-        iosX64(),
-        iosArm64(),
-    ).forEach {
-        it.binaries.framework {
-            baseName = "mutator-coroutines"
-        }
-    }
-
     sourceSets {
         val commonMain by getting {
             dependencies {
@@ -41,20 +31,6 @@ kotlin {
                 implementation(libs.kotlinx.coroutines.test)
                 implementation(libs.cashapp.turbine)
             }
-        }
-        val iosX64Main by getting
-        val iosArm64Main by getting
-        val iosMain by creating {
-            dependsOn(commonMain)
-            iosX64Main.dependsOn(this)
-            iosArm64Main.dependsOn(this)
-        }
-        val iosX64Test by getting
-        val iosArm64Test by getting
-        val iosTest by creating {
-            dependsOn(commonTest)
-            iosX64Test.dependsOn(this)
-            iosArm64Test.dependsOn(this)
         }
         all {
             languageSettings.apply {

--- a/coroutines/build.gradle.kts
+++ b/coroutines/build.gradle.kts
@@ -16,9 +16,19 @@
 
 plugins {
     `kotlin-library-convention`
+    kotlin("multiplatform")
 }
 
 kotlin {
+    listOf(
+        iosX64(),
+        iosArm64(),
+    ).forEach {
+        it.binaries.framework {
+            baseName = "mutator-coroutines"
+        }
+    }
+
     sourceSets {
         val commonMain by getting {
             dependencies {
@@ -31,6 +41,20 @@ kotlin {
                 implementation(libs.kotlinx.coroutines.test)
                 implementation(libs.cashapp.turbine)
             }
+        }
+        val iosX64Main by getting
+        val iosArm64Main by getting
+        val iosMain by creating {
+            dependsOn(commonMain)
+            iosX64Main.dependsOn(this)
+            iosArm64Main.dependsOn(this)
+        }
+        val iosX64Test by getting
+        val iosArm64Test by getting
+        val iosTest by creating {
+            dependsOn(commonTest)
+            iosX64Test.dependsOn(this)
+            iosArm64Test.dependsOn(this)
         }
         all {
             languageSettings.apply {


### PR DESCRIPTION
This adds iOS targets to each module. I tested this locally by publishing to my local maven & running it on each platform. 

TBH I'm not sure if it can be simplified, idk if I could have just made an `ios()` target but I copied from another project & this worked. 